### PR TITLE
Minishift needs at least 8 GB of RAM

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -13,6 +13,8 @@ Things to do:
 
 ## Deploy EnMasse
 
+> If you are going to deploy Eclipse Hono and EnMasse using Minishift, you would need at least 8 GB of RAM for running the builds and deploying all the needed containers; start Minishift with the following command `minishift start --memory 4GB`
+
 Login in to OpenShift and create a new EnMasse project:
 
 ~~~sh


### PR DESCRIPTION
It seems to me that using Minishift, it needs at least 8 GB of RAM.
Using only 2 GB, all the running builds brake OpenShift.
Using only 4 GB, the builds work but then some of the Pods are pending for insufficient memory.
It should be mentioned in the setup instructions.